### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -10,6 +10,7 @@
   ],
   "description" : "CLI related functions.",
   "name" : "Term::Choose::Util",
+  "license" : "Artistic-2.0",
   "perl" : "6.c",
   "provides" : {
     "Term::Choose::Util" : "lib/Term/Choose/Util.pm6"


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license